### PR TITLE
Renamed configurable `grouped()` to `group()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Please check the [releases](https://github.com/mochidev/HostRouter/releases) for
 ```swift
 dependencies: [
     .package(url: "https://github.com/vapor/vapor.git", from: "4.90.0"),
-    .package(url: "https://github.com/mochidev/HostRouter.git", .upToNextMinor(from: "0.1.0")),
+    .package(url: "https://github.com/mochidev/HostRouter.git", .upToNextMinor(from: "0.2.0")),
 ],
 ...
 targets: [

--- a/Sources/HostRouter/HostRoutesGroup.swift
+++ b/Sources/HostRouter/HostRoutesGroup.swift
@@ -47,15 +47,15 @@ extension HostRoutesBuilder {
         HostRoutesGroup(root: self, port: nil, domainPath: reverseDomain)
     }
     
-    public func grouped(subDomain: some StringProtocol, configure: (HostRoutesBuilder) throws -> ()) rethrows {
+    public func group(subDomain: some StringProtocol, configure: (HostRoutesBuilder) throws -> ()) rethrows {
         try configure(HostRoutesGroup(root: self, port: nil, domainPath: subDomain.reversedDomainComponents))
     }
     
-    public func grouped(reverseDomain: HostComponent..., configure: (HostRoutesBuilder) throws -> ()) rethrows {
+    public func group(reverseDomain: HostComponent..., configure: (HostRoutesBuilder) throws -> ()) rethrows {
         try configure(HostRoutesGroup(root: self, port: nil, domainPath: reverseDomain))
     }
     
-    public func grouped(reverseDomain: [HostComponent], configure: (HostRoutesBuilder) throws -> ()) rethrows {
+    public func group(reverseDomain: [HostComponent], configure: (HostRoutesBuilder) throws -> ()) rethrows {
         try configure(HostRoutesGroup(root: self, port: nil, domainPath: reverseDomain))
     }
 }

--- a/Sources/HostRouter/HostRoutesGroup.swift
+++ b/Sources/HostRouter/HostRoutesGroup.swift
@@ -32,6 +32,10 @@ extension TopLevelHostRoutesBuilder {
     public func grouped(host: some StringProtocol) -> some HostRoutesBuilder {
         HostRoutesGroup(root: self, port: nil, domainPath: host.reversedDomainComponents)
     }
+    
+    public func group(host: some StringProtocol, configure: (HostRoutesBuilder) throws -> ()) rethrows {
+        try configure(HostRoutesGroup(root: self, port: nil, domainPath: host.reversedDomainComponents))
+    }
 }
 
 extension HostRoutesBuilder {


### PR DESCRIPTION
Also added a missing `group(host:configure:)` permutation.